### PR TITLE
Output coverage report and report only src/lib.rs

### DIFF
--- a/.ci/test-cover
+++ b/.ci/test-cover
@@ -19,37 +19,40 @@ DESTDIR="${PWD}/target/cover"
 rustup component add llvm-tools
 cargo install grcov "cargo-pgrx@${PGRXVERSION}"
 
-export RUSTFLAGS="-Cinstrument-coverage"
+export RUSTFLAGS="-C instrument-coverage"
 if [ "$(uname -o)" = "Darwin" ]; then
     export RUSTFLAGS="-Clink-arg=-Wl,-undefined,dynamic_lookup $RUSTFLAGS"
 fi
 
 coverargs=()
+prof_dirs=("${DESTDIR}")
 if [ -n "${PGUSER}" ]; then
     coverargs+=(--runas "$PGUSER")
 fi
 if [ -n "${PGDATA}" ]; then
     coverargs+=(--pgdata "$PGDATA")
+    if [ -n "${PGUSER}" ]; then
+        # The pg_test tests will be run here, and LLVM_PROFILE_FILE won't be
+        # propagated, so be sure to tell grcov to look for files here.
+        prof_dirs+=("${PGDATA}/${PGVERSION}")
+    fi
 fi
 
 export LLVM_PROFILE_FILE="${DESTDIR}/default_%m_%p.profraw"
 cargo pgrx test "${coverargs[@]}" "pg${PGVERSION}"
 
-grcov "${DESTDIR}" \
-    --ignore '**/clang-sys*/**' \
-    --ignore '**/pgrx-pg-sys*/**' \
-    --ignore "$HOME/.cargo/**" \
+grcov "${prof_dirs[@]}" \
+    --keep-only src/lib.rs \
     --ignore-not-existing \
-    --excl-start 'begin_impossible!' \
-    --excl-stop 'end_impossible!' \
+    --excl-line 'unreachable!' \
     --llvm \
     --binary-path "target/debug/" \
     -s . \
     --branch \
     -o "${DESTDIR}" \
-    --output-types html,cobertura
+    --output-types html,cobertura,markdown
 
-xmllint --xpath "concat('Coverage: ', 100 * string(//coverage/@line-rate), '%')" "${DESTDIR}/cobertura.xml"
+cat "${DESTDIR}/markdown.md"
 
 if [ "$(uname -o)" = "Darwin" ] && [ -z "$CI" ]; then
 	open "${DESTDIR}/html/index.html"

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Start PostgreSQL ${{ env.PGVERSION }}
-        run: pg-start ${{ env.PGVERSION }} libxml2-utils
+        run: pg-start ${{ env.PGVERSION }}
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this project will be documented in this file. It uses the
     installed elsewhere in `dynamic_library_path` Postgres will be able to
     find it.
 *   Moved from the `tembo-io` org to `theory` on GitHub.
+*   Reduced memory overhead of some error values, as suggested by the Rust
+    1.87.0 linter.
 
   [v0.1.7]: https://github.com/theory/pg-jsonschema-boon/compare/v0.1.6...v0.1.7
 


### PR DESCRIPTION
Add markdown output and `cat` it to print a plain text coverage report. It helped figure out that the GitHub workflow was including a ton of files from `/usr/share/cargo/registry` in the report, so tell `grcov` to only keep `src/lib.rs`.